### PR TITLE
Update the checkout action to v5.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Test
         run: make test


### PR DESCRIPTION
This is the only out-of-date dependency at the moment. No new lints with the latest stable Rust toolchain either.