### PR TITLE
Fix the error if a branch name matches a filename.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,7 @@ fn includes_excludes(
         .args(interesting_branches)
         .arg("--not")
         .args(merge_bases)
+        .arg("--")
         .stdout(Stdio::piped())
         .spawn()
         .expect("failed to run git");


### PR DESCRIPTION
The `git rev-list` invocation becomes ambiguous if a local branch name matches a filename, resulting in an error. This appends a `--` argument to tell `git` that every argument we pass is a branch and not a file.