### PR TITLE
Handle the "not a git repository" case better.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ blanket_clippy_restriction_lints = "allow"
 cargo = { level = "deny", priority = -1 }
 complexity = { level = "deny", priority = -1 }
 correctness = { level = "deny", priority = -1 }
+default_numeric_fallback = "allow"
 else_if_without_else = "allow"
 expect_used = "allow"
 get_unwrap = "allow"


### PR DESCRIPTION
`git` already prints out an error code if `git-tree` is run in a directory that is not in a git repository. Rather than panicing, this does a clean silent exit to keep the console output cleaner.